### PR TITLE
centralise colour logic

### DIFF
--- a/objects/obj_event_log/Draw_0.gml
+++ b/objects/obj_event_log/Draw_0.gml
@@ -20,7 +20,7 @@ if (__b__) {
         draw_set_color(c_gray); // 38144
         draw_set_font(fnt_40k_30b);
         draw_set_halign(fa_center);
-        draw_text(xx + 800, yy + 74, string_hash_to_newline(string(global.chapter_name) + " Event Log"));
+        draw_text(xx + 800, yy + 74, string(global.chapter_name) + " Event Log");
         draw_set_halign(fa_left);
         var t = 0,
             p = -1,
@@ -28,33 +28,16 @@ if (__b__) {
         var ent = array_length(event);
         draw_set_color(38144);
         if (ent == 0) {
-            draw_text(xx + 25, yy + 120, string_hash_to_newline("No entries logged."));
+            draw_text(xx + 25, yy + 120, "No entries logged.");
         } else {
-            t = top - 2;
             p = -1;
             draw_set_font(fnt_40k_14);
             draw_set_alpha(0.8);
-            repeat(25) {
-                t++;
+            for (var t=top - 1; t<ent; t++){
                 p++;
-                if (t >= ent) {
-                    break;
-                }
                 cur_event = event[t];
                 if (cur_event.text != "") { // 1554
-                    if (cur_event.colour == "" || cur_event.colour == "green") {
-                        draw_set_color(38144);
-                    } else if (cur_event.colour == "red") {
-                        draw_set_color(c_red);
-                    } else if (cur_event.colour == "yellow") {
-                        draw_set_color(57586);
-                    } else if (cur_event.colour == "purple") {
-                        draw_set_color(c_purple);
-                    } else if (cur_event.colour != "") {
-                        draw_set_color(cur_event.colour);
-                    } else {
-                        debugl("DEBUG: color fallthrough in obj_event_log/Draw_0.gml!");
-                    }
+                    set_alert_draw_colour(cur_event.colour);
                     draw_text_ext(xx + 25, yy + 120 + (p * 26), $"{cur_event.date}  (Turn {cur_event.turn}) - {cur_event.text}", -1, 1554);
                     if (cur_event.event_target != "none") {
                         if (point_and_click(draw_unit_buttons([xx + 1400, yy + 120 + (p * 26)], "View", [1, 1], c_green, , fnt_40k_14b, 1,true))) {

--- a/objects/obj_event_log/Draw_0.gml
+++ b/objects/obj_event_log/Draw_0.gml
@@ -42,12 +42,18 @@ if (__b__) {
                 }
                 cur_event = event[t];
                 if (cur_event.text != "") { // 1554
-                    draw_set_color(38144);
-                    if (cur_event.colour = "red") {
+                    if (cur_event.colour == "" || cur_event.colour == "green") {
+                        draw_set_color(38144);
+                    } else if (cur_event.colour == "red") {
                         draw_set_color(c_red);
-                    }
-                    if (cur_event.colour = "purple") {
+                    } else if (cur_event.colour == "yellow") {
+                        draw_set_color(57586);
+                    } else if (cur_event.colour == "purple") {
                         draw_set_color(c_purple);
+                    } else if (cur_event.colour != "") {
+                        draw_set_color(cur_event.colour);
+                    } else {
+                        debugl("DEBUG: color fallthrough in obj_event_log/Draw_0.gml!");
                     }
                     draw_text_ext(xx + 25, yy + 120 + (p * 26), $"{cur_event.date}  (Turn {cur_event.turn}) - {cur_event.text}", -1, 1554);
                     if (cur_event.event_target != "none") {

--- a/objects/obj_turn_end/Draw_64.gml
+++ b/objects/obj_turn_end/Draw_64.gml
@@ -15,10 +15,19 @@ if (alerts>0) and (popups_end=1){
     repeat(alerts){
         i+=1;
 
-        draw_set_color(38144);
-        if (alert_color[i] == "red") then draw_set_color(c_red);
-        if (alert_color[i] == "yellow") then draw_set_color(57586);
-        // if (alert_color[i]="purple") then draw_set_color(c_red);
+        if (alert_color[i] == "" || alert_color[i] == "green") {
+            draw_set_color(38144);
+        } else if (alert_color[i] == "red") {
+            draw_set_color(c_red);
+        } else if (alert_color[i] == "yellow") {
+            draw_set_color(57586);
+        } else if (alert_color[i] == "purple") {
+            draw_set_color(c_purple);
+        } else if (alert_color[i] != "") {
+            draw_set_color(alert_color[i]);
+        } else {
+            debugl("DEBUG: color fallthrough in obj_turn_end/Draw_64.gml!");
+        }
         draw_set_alpha(min(1,alert_alpha[i]));
         
         if (obj_controller.zoomed=0){

--- a/objects/obj_turn_end/Draw_64.gml
+++ b/objects/obj_turn_end/Draw_64.gml
@@ -14,20 +14,7 @@ if (alerts>0) and (popups_end=1){
 	
     repeat(alerts){
         i+=1;
-
-        if (alert_color[i] == "" || alert_color[i] == "green") {
-            draw_set_color(38144);
-        } else if (alert_color[i] == "red") {
-            draw_set_color(c_red);
-        } else if (alert_color[i] == "yellow") {
-            draw_set_color(57586);
-        } else if (alert_color[i] == "purple") {
-            draw_set_color(c_purple);
-        } else if (alert_color[i] != "") {
-            draw_set_color(alert_color[i]);
-        } else {
-            debugl("DEBUG: color fallthrough in obj_turn_end/Draw_64.gml!");
-        }
+        set_alert_draw_colour(alert_color[i]);
         draw_set_alpha(min(1,alert_alpha[i]));
         
         if (obj_controller.zoomed=0){

--- a/scripts/scr_alert/scr_alert.gml
+++ b/scripts/scr_alert/scr_alert.gml
@@ -12,7 +12,7 @@ function scr_alert(colour, alert_type, alert_text, xx=00, yy=00) {
 	    if (obj_turn_end.alert_type[obj_turn_end.alerts]!="-"+string(alert_text)) and (alert_type!="blank") and (colour!="blank"){
 	        obj_turn_end.alerts+=1;
 	        obj_turn_end.alert[obj_turn_end.alerts]=1;
-	        obj_turn_end.alert_color[obj_turn_end.alerts]=colour;
+	        obj_turn_end.alert_color[obj_turn_end.alerts]=colour; // takes green, red, purple, default GM colorcodes(with c_ prefix), decimal, hexadecimal(with $ prefix, 6 or 8 digits) and CSS(with # prefix)
 	        // if (colour="purple") then obj_turn_end.alert_color[obj_turn_end.alerts]="red";
 	        obj_turn_end.alert_type[obj_turn_end.alerts]=alert_type;
 	        obj_turn_end.alert_text[obj_turn_end.alerts]="-"+string(alert_text);

--- a/scripts/scr_alert/scr_alert.gml
+++ b/scripts/scr_alert/scr_alert.gml
@@ -12,7 +12,7 @@ function scr_alert(colour, alert_type, alert_text, xx=00, yy=00) {
 	    if (obj_turn_end.alert_type[obj_turn_end.alerts]!="-"+string(alert_text)) and (alert_type!="blank") and (colour!="blank"){
 	        obj_turn_end.alerts+=1;
 	        obj_turn_end.alert[obj_turn_end.alerts]=1;
-	        obj_turn_end.alert_color[obj_turn_end.alerts]=colour; // takes green, red, purple, default GM colorcodes(with c_ prefix), decimal, hexadecimal(with $ prefix, 6 or 8 digits) and CSS(with # prefix)
+	        obj_turn_end.alert_color[obj_turn_end.alerts]=colour; // takes green, yellow, red, purple, default GM colorcodes(with c_ prefix), decimal, hexadecimal(with $ prefix, 6 or 8 digits) and CSS(with # prefix)
 	        // if (colour="purple") then obj_turn_end.alert_color[obj_turn_end.alerts]="red";
 	        obj_turn_end.alert_type[obj_turn_end.alerts]=alert_type;
 	        obj_turn_end.alert_text[obj_turn_end.alerts]="-"+string(alert_text);

--- a/scripts/scr_alert/scr_alert.gml
+++ b/scripts/scr_alert/scr_alert.gml
@@ -1,3 +1,29 @@
+function set_alert_draw_colour(alert_colour){
+	static default_colour = 38144;
+	static colour_map = {
+		"red" : c_red,
+		"yellow" : 57586,
+		"purple" : c_purple,
+		"green" : 38144,
+	}//TODO set constants for colours
+	if (alert_colour!=""){
+		if (struct_exists(colour_map, alert_colour)){
+			draw_set_color(colour_map[$ alert_colour]);
+		} else {
+			try{
+				draw_set_color(alert_colour);
+			} catch(_exception){
+				debugl("DEBUG: color fallthrough in set_alert_draw_colour!");
+				draw_set_color(default_colour);
+			}
+		}
+	} else {
+		draw_set_color(default_colour);
+	}else {
+        debugl("DEBUG: color fallthrough in set_alert_draw_colour!");
+    }
+}
+
 function scr_alert(colour, alert_type, alert_text, xx=00, yy=00) {
 
 	// color / type / text /x/y

--- a/scripts/scr_event_log/scr_event_log.gml
+++ b/scripts/scr_event_log/scr_event_log.gml
@@ -7,7 +7,7 @@ function scr_event_log(event_colour, event_text, target = "none") {
 	    if (obj_controller.year_fraction>=100) then yf=string(obj_controller.year_fraction);
 
 		var new_event = {
-			colour :event_colour,
+			colour :event_colour, // takes green, red, purple, default GM colorcodes(with c_ prefix), decimal, hexadecimal(with $ prefix, 6 or 8 digits) and CSS(with # prefix)
 			turn : obj_controller.turn,
 	    	date:string(obj_controller.check_number)+" "+string(yf)+" "+string(obj_controller.year)+".M"+string(obj_controller.millenium),
 	   	 	text:event_text,

--- a/scripts/scr_event_log/scr_event_log.gml
+++ b/scripts/scr_event_log/scr_event_log.gml
@@ -7,7 +7,7 @@ function scr_event_log(event_colour, event_text, target = "none") {
 	    if (obj_controller.year_fraction>=100) then yf=string(obj_controller.year_fraction);
 
 		var new_event = {
-			colour :event_colour, // takes green, red, purple, default GM colorcodes(with c_ prefix), decimal, hexadecimal(with $ prefix, 6 or 8 digits) and CSS(with # prefix)
+			colour :event_colour, // takes green, yellow, red, purple, default GM colorcodes(with c_ prefix), decimal, hexadecimal(with $ prefix, 6 or 8 digits) and CSS(with # prefix)
 			turn : obj_controller.turn,
 	    	date:string(obj_controller.check_number)+" "+string(yf)+" "+string(obj_controller.year)+".M"+string(obj_controller.millenium),
 	   	 	text:event_text,


### PR DESCRIPTION
## Description of changes
- centralise setting colours colours for various alert systems
## Reasons for changes
- annoying and inconsistent to have the same logic in two places
## Related links
-
## How have you tested your changes?
- [ ] Compile
- [ ] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
